### PR TITLE
feat: simulate 1min clock cycle in 5sec real time

### DIFF
--- a/src/OOP/JetBrains/Clock/Clock_Work.java
+++ b/src/OOP/JetBrains/Clock/Clock_Work.java
@@ -1,14 +1,15 @@
 package OOP.JetBrains.Clock;
+import java.util.concurrent.TimeUnit;
 
 public class Clock_Work {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws InterruptedException {
         Clock clock = new Clock();
-        // cycles are used to simulate 24h
-        int cycles = 0;
-        while (cycles < 720) {
+
+        while (true) {
             clock.next();
             System.out.printf("%d:%d%d%n", clock.hours, clock.minutes1, clock.minutes2);
-            cycles++;
+            TimeUnit.SECONDS.sleep(5);
+
         }
     }
 }


### PR DESCRIPTION
I removed the cycles, and it related implementations in regard of the implementation of a mor realistic time simulation. The current starting time will be displayed and the program then sleeps for 5 seconds, before another time will be shown.